### PR TITLE
feat(debate): production hardening v6.0.0 — consistency, robustness, output contract

### DIFF
--- a/skills/debate/README.md
+++ b/skills/debate/README.md
@@ -28,28 +28,35 @@ AI Debate Hub creates a three-way discussion where all three AI systems analyze 
 |  to both  to both  to both |
 +---------------------------+
               |
-              v
+              v (early-stop if consensus)
 +---------------------------+
 |       SYNTHESIS           |
 +---------------------------+
-|   All 3 perspectives      |
+|   Advisor summary table   |
+|   Consensus + disputes    |
+|   Risks & failure modes   |
 |   Claude's recommendation |
 +---------------------------+
 ```
 
-## Features
-
-- **Multi-round debates**: Configurable 1-10 rounds of back-and-forth
-- **Session persistence**: Advisors maintain context across rounds via session UUIDs
-- **Multiple debate styles**: quick, thorough, adversarial, collaborative
-- **Automatic synthesis**: Generates summary of agreements, disagreements, and recommendations
-- **Token efficient**: Only injects other advisor's response (each remembers own context)
-
 ## Requirements
 
-- [Claude Code CLI](https://github.com/anthropics/claude-code)
-- [Gemini CLI](https://github.com/google-gemini/gemini-cli) - `npm install -g @anthropic-ai/gemini-cli`
-- [Codex CLI](https://github.com/openai/codex) - OpenAI's coding assistant
+| Dependency | Required | Notes |
+|-----------|----------|-------|
+| [Claude Code CLI](https://github.com/anthropics/claude-code) | Yes | Orchestrator + participant |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Yes | `npm install -g @google/gemini-cli` |
+| [Codex CLI](https://github.com/openai/codex) | Yes | OpenAI's coding assistant |
+| `bash` | Yes | Shell for helper scripts (or WSL on Windows) |
+| `jq` | Recommended | JSON validation in atomic writes |
+| `flock` | Optional | File locking (Linux). Fallback exists without it |
+| Node.js 18+ | Optional | Cross-platform alternative to bash helpers |
+
+### Windows Users
+
+Two options:
+
+1. **WSL (recommended)** — Run everything inside WSL. All bash helpers work natively.
+2. **Node.js alternative** — Use `tools/atomic-json.mjs` instead of bash helpers for state/index management. No `flock` or `jq` needed.
 
 ## Installation
 
@@ -66,20 +73,20 @@ Or copy just the debate skill:
 cp -r claude-skills/skills/debate ~/.claude/skills/
 ```
 
-## Usage
+## Quickstart
 
-### Basic Invocation
-```
+```bash
+# Simple one-round debate
 /debate Should we use Redis or in-memory cache for our session store?
-```
 
-### With Options
-```
+# Three-round thorough analysis
 /debate -r 3 -d thorough Review our authentication implementation
-/debate --rounds 2 --debate-style adversarial Is this API design secure?
+
+# Adversarial with authoritative moderator
+/debate -r 2 -d adversarial -m authoritative Is this API design secure?
 ```
 
-### Flags
+## Flags
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
@@ -87,6 +94,14 @@ cp -r claude-skills/skills/debate ~/.claude/skills/
 | `--debate-style STYLE` | `-d STYLE` | quick | Style: quick, thorough, adversarial, collaborative |
 | `--moderator-style MODE` | `-m MODE` | guided | Mode: transparent, guided, authoritative |
 | `--max-words N` | `-w N` | 300 | Word limit per response |
+
+### Moderator Styles
+
+| Mode | Behavior |
+|------|----------|
+| `transparent` | Claude presents all views neutrally, minimal editorial voice |
+| `guided` | Claude highlights key disagreements and steers toward resolution |
+| `authoritative` | Claude takes strong positions and challenges weak arguments |
 
 ## Architecture
 
@@ -99,8 +114,8 @@ Each advisor maintains its own session for context continuity:
 
 ```bash
 # Gemini (from project root)
-gemini -y "Initial prompt..."
-gemini -r <UUID> -y "Follow-up..."
+gemini -y -o text "Initial prompt..."
+gemini -r <UUID> -y -o text "Follow-up..."
 
 # Codex (from debate folder)
 codex exec --full-auto "Initial prompt..."
@@ -119,23 +134,38 @@ Round 2+ (all three respond):
 |-- Gemini responds to Codex + Claude
 |-- Codex responds to Gemini + Claude
 +-- Claude responds to Gemini + Codex (YOUR contribution)
+    └── Early-stop check: if strong consensus, skip remaining rounds
 
 Synthesis:
-+-- All three perspectives consolidated
++-- Advisor summary table (position, confidence, assumptions)
 +-- Points of agreement across all three
 +-- Points of disagreement
++-- Risks & failure modes
 +-- Claude's final recommendation
 ```
+
+### Output Contract
+
+Each advisor response follows a structured format for comparability:
+
+- **Position** (1 line)
+- **Key Arguments** (bullets)
+- **Assumptions**
+- **Risks / Failure Modes**
+- **What Would Change My Mind**
+- **Confidence** (0-100%)
+
+This makes synthesis meaningful — you can cross-compare assumptions and confidence levels.
 
 ### File Structure
 
 ```
 {project}/debates/
 |-- viewer.html             # Auto-deployed from skill folder
-|-- index.json              # Debate registry for viewer
+|-- index.json              # Debate registry for viewer (atomic writes)
 +-- NNN-topic-slug/
     |-- context.md          # Initial context
-    |-- state.json          # Session UUIDs, status
+    |-- state.json          # Session UUIDs, status, telemetry
     |-- transcript.md       # Combined chronological record
     |-- synthesis.md        # Final synthesis (all 3 perspectives)
     +-- rounds/
@@ -159,10 +189,11 @@ python -m http.server 8000
 ```
 
 The viewer shows:
-- **Synthesis** - Final analysis and recommendations
-- **Rounds** - Side-by-side comparison (2 or 3 columns)
-- **Transcript** - Full chronological debate record
-- **State** - Debug view of debate metadata
+- **Synthesis** — Final analysis and recommendations (with copy-to-clipboard)
+- **Rounds** — Side-by-side comparison (2 or 3 columns)
+- **Transcript** — Full chronological debate record
+- **Context** — Original question and configuration
+- **State** — Debug view of debate metadata + telemetry
 
 ## Debate Styles
 
@@ -184,29 +215,48 @@ Run a simple test debate:
 
 Verify session continuity by checking token growth in Codex output.
 
-### Version History
+### Test Checklist
 
-- **v4.7** (current) - Three-way debate structure
-  - Claude is now an active PARTICIPANT, not just orchestrator
-  - Each round has contributions from all three: Gemini, Codex, Claude
-  - Advisors receive responses from BOTH other participants
-  - Claude's responses saved to r00N_claude.md files
-
-- **v4.6** - Production-ready architecture
-  - Gemini runs from project root for file access
-  - Both advisors use explicit UUID tracking
-  - Full e2e tested and validated
-
-- **v4.5** - Fixed Codex syntax, removed broken flags
-- **v4.4** - Added session UUID persistence
-- **v4.3** - Flag precedence rules, synthesis workflow
-- **v4.2** - Session folder scoping documentation
+- [ ] Single round debate generates complete folder structure
+- [ ] 3-round debate respects session persistence across rounds
+- [ ] Simulated rate-limit triggers retry and records `last_error` in state.json
+- [ ] Two parallel debates don't corrupt `index.json`
+- [ ] `viewer.html` renders without errors and copy-to-clipboard works
 
 ## Known Limitations
 
 1. **Gemini `--include-directories`**: Flag exists but doesn't work; run from project root instead
 2. **Codex `-C` flag**: Doesn't bypass trust requirements; use `cd` instead
 3. **Codex rate limits**: May hit usage limits on extended debates
+
+## Version History
+
+- **v6.0.0** (current) — Production hardening
+  - Unified version across all files
+  - Added `--moderator-style` flag (transparent, guided, authoritative)
+  - Structured output contract per advisor (position, confidence, assumptions, risks)
+  - Early-stop on consensus detection
+  - Error telemetry in state.json (round durations, retries, last_error)
+  - Atomic index.json writes (parallel-safe)
+  - Cross-platform Node.js helper (`tools/atomic-json.mjs`)
+  - Enhanced viewer with copy-to-clipboard
+  - `disable-model-invocation: true` in frontmatter
+
+- **v4.7** — Three-way debate structure
+  - Claude is now an active PARTICIPANT, not just orchestrator
+  - Each round has contributions from all three: Gemini, Codex, Claude
+  - Advisors receive responses from BOTH other participants
+  - Claude's responses saved to r00N_claude.md files
+
+- **v4.6** — Production-ready architecture
+  - Gemini runs from project root for file access
+  - Both advisors use explicit UUID tracking
+  - Full e2e tested and validated
+
+- **v4.5** — Fixed Codex syntax, removed broken flags
+- **v4.4** — Added session UUID persistence
+- **v4.3** — Flag precedence rules, synthesis workflow
+- **v4.2** — Session folder scoping documentation
 
 ## License
 

--- a/skills/debate/SKILL.md
+++ b/skills/debate/SKILL.md
@@ -1,26 +1,35 @@
 ---
 name: debate
-description: Use when a user wants a structured multi-model debate using Claude, Gemini CLI, and OpenAI Codex CLI, with configurable rounds and debate style.
+description: Multi-LLM debate orchestration (Claude vs Codex vs Gemini) with rounds + synthesis.
+disable-model-invocation: true
 ---
 
-# AI Debate Hub Skill v6.0
+# AI Debate Hub Skill v6.0.0
 
 You are Claude, a **participant and moderator** in a three-way AI debate. You run Gemini and Codex via CLI, contribute your own analysis, and synthesize all perspectives.
 
 **You are NOT just an orchestrator. You are an active participant with your own voice.**
+
+> This skill runs by explicit command only (`/debate`). It will never auto-invoke.
 
 ---
 
 ## Parsing Invocation
 
 ```
-/debate [-r N] [-d STYLE] [-w N] <question or task>
+/debate [-r N] [-d STYLE] [-m MODE] [-w N] <question or task>
 ```
 
 **Flags:**
 - `-r N` / `--rounds N` — Number of rounds (1-10, default: 1)
 - `-d STYLE` / `--debate-style STYLE` — quick|thorough|adversarial|collaborative
+- `-m MODE` / `--moderator-style MODE` — transparent|guided|authoritative (default: guided)
 - `-w N` / `--max-words N` — Word limit per response (default: 300)
+
+**Moderator styles:**
+- `transparent` — Claude presents all views neutrally, minimal editorial voice
+- `guided` (default) — Claude highlights key disagreements and steers toward resolution
+- `authoritative` — Claude takes strong positions and challenges weak arguments
 
 **Style defaults (when --rounds not specified):** quick=1, thorough=3, adversarial=3, collaborative=2
 
@@ -48,19 +57,30 @@ You are Claude, a **participant and moderator** in a three-way AI debate. You ru
 4. **Initialize state.json:**
    ```json
    {
-     "version": 1,
+     "version": 2,
      "debate_id": "NNN-topic-slug",
      "topic": "Human readable topic",
      "status": "in_progress",
      "current_round": 0,
      "rounds_total": N,
+     "moderator_style": "guided",
      "participants": ["gemini", "codex", "claude"],
      "created_at": "ISO-8601",
-     "sessions": {}
+     "sessions": {},
+     "telemetry": {
+       "round_durations": {},
+       "retries_count": 0
+     },
+     "last_error": null
    }
    ```
 
-5. **Update index.json** — Add debate folder name to the `debates` array
+   **Telemetry fields:**
+   - `round_durations` — Object mapping round number to seconds: `{"1": 45, "2": 38}`
+   - `retries_count` — Total retry attempts across all rounds
+   - `last_error` — `null` or `{"type": "rate_limit", "message": "429 Too Many Requests", "round": 2, "advisor": "gemini", "timestamp": "ISO-8601"}`
+
+5. **Update index.json atomically** — Add debate folder name to the `debates` array. Use `update_debate_index()` from helpers.md to prevent corruption during parallel debates.
 
 ### Phase 2: Run Rounds
 
@@ -82,8 +102,9 @@ Provide initial analysis. {max_words} words max."
 
 After both respond:
 - Save responses to `rounds/r001_gemini.md` and `rounds/r001_codex.md`
-- Write YOUR analysis to `rounds/r001_claude.md`
+- Write YOUR analysis to `rounds/r001_claude.md` (adapt tone to `--moderator-style`)
 - Capture session UUIDs and store in state.json
+- Record round duration in `telemetry.round_durations`
 
 **Round 2+ — All three respond to each other:**
 
@@ -105,6 +126,8 @@ After both respond:
 - Save to `rounds/r00N_gemini.md`, `rounds/r00N_codex.md`
 - Write YOUR response to `rounds/r00N_claude.md`
 - Update `current_round` in state.json
+- Record round duration in `telemetry.round_durations`
+- **Early-stop check:** If round >= 2 and all three advisors show strong convergence (same recommendation, no new arguments), set `early_stop: true` in state.json with `early_stop_reason: "consensus"` and skip remaining rounds
 
 ### Phase 3: Handle Failures
 
@@ -116,14 +139,36 @@ On failure, read `helpers.md` in this skill folder for retry logic and error han
 - Session expired → Create new session with full context
 - Usage limit → Skip advisor, continue with others
 
+**Always record failures in state.json:**
+```json
+{
+  "last_error": {
+    "type": "rate_limit",
+    "message": "429 Too Many Requests (capped at 200 chars)",
+    "round": 2,
+    "advisor": "gemini",
+    "timestamp": "ISO-8601"
+  },
+  "telemetry": { "retries_count": 3 }
+}
+```
+
 ### Phase 4: Synthesis
 
-After all rounds complete:
+After all rounds complete (or early-stop triggered):
 
 1. **Create transcript.md** — Combine all rounds chronologically
-2. **Create synthesis.md:**
+2. **Create synthesis.md** using the structured output contract:
    ```markdown
    # Debate Synthesis: {topic}
+
+   ## Advisor Summary
+
+   | Advisor | Position | Confidence | Key Assumption |
+   |---------|----------|------------|----------------|
+   | Gemini  | ...      | XX%        | ...            |
+   | Codex   | ...      | XX%        | ...            |
+   | Claude  | ...      | XX%        | ...            |
 
    ## Consensus (All Agree)
    - Point 1
@@ -132,6 +177,11 @@ After all rounds complete:
    ## Disputed Issues
    - Issue: [Gemini view] vs [Codex view] vs [Claude view]
 
+   ## Risks & Failure Modes
+   | Risk | Raised by | Severity |
+   |------|-----------|----------|
+   | ...  | Gemini    | High     |
+
    ## Recommendations
    | Priority | Action | Source |
    |----------|--------|--------|
@@ -139,21 +189,58 @@ After all rounds complete:
 
    ## Conclusion
    {Your final recommendation}
+
+   ## Metadata
+   - Rounds completed: {N}
+   - Early stop: {yes/no} ({reason if yes})
+   - Total duration: {sum of round_durations}s
    ```
 
 3. **Update state.json:** Set `status: "completed"`, add `completed_at`
 
 ---
 
+## Advisor Output Contract
+
+Each advisor response (including yours) should follow this structure:
+
+```markdown
+**Position:** {1-line summary of recommendation}
+
+**Key Arguments:**
+- Argument 1
+- Argument 2
+
+**Assumptions:**
+- What I'm taking for granted
+
+**Risks / Failure Modes:**
+- What could go wrong with my approach
+
+**What Would Change My Mind:**
+- Evidence or argument that would shift my position
+
+**Confidence:** {0-100}%
+```
+
+When prompting Gemini and Codex, include this structure in the prompt so their responses are comparable. **Do not invent facts; if uncertain, say so explicitly.**
+
+---
+
 ## Your Contributions
 
-Each round, write YOUR analysis to `rounds/r00N_claude.md`:
+Each round, write YOUR analysis to `rounds/r00N_claude.md` following the output contract above.
 
 **DO NOT just summarize. PARTICIPATE.**
 
 Wrong: "Gemini said X, Codex said Y. Both make good points."
 
 Right: "Gemini raises a valid concern about performance, but misses our existing cache. Codex's security point is critical—I agree. However, BOTH missed the rate limiting vulnerability. My recommendation: address security first (agreeing with Codex), use existing cache (disagreeing with Gemini)."
+
+**Adapt tone to `--moderator-style`:**
+- `transparent` — Present your position alongside others, equal weight
+- `guided` — Highlight the strongest arguments, steer toward resolution
+- `authoritative` — Take a firm stance, challenge weak reasoning directly
 
 ---
 
@@ -196,9 +283,16 @@ debates/
 ## Helper Functions
 
 For error handling, retry logic, and atomic state updates, read:
-`~/.claude/skills/debate/helpers.md`
+`helpers.md` in this skill folder.
 
 This contains:
 - `update_debate_state()` — Safe atomic state writes
-- `run_advisor_with_retry()` — Exponential backoff retry
+- `update_debate_index()` — Safe atomic index.json writes (parallel-safe)
+- `run_advisor_with_retry()` — Exponential backoff retry with telemetry
 - `log_contextual_error()` — User-friendly error output
+
+**Cross-platform alternative:** For Windows/macOS without `flock`, use:
+```bash
+node tools/atomic-json.mjs write state.json '<json>'
+node tools/atomic-json.mjs append-index index.json '<entry-json>'
+```

--- a/skills/debate/helpers.md
+++ b/skills/debate/helpers.md
@@ -1,6 +1,8 @@
-# AI Debate Hub - Helper Functions
+# AI Debate Hub - Helper Functions v6.0.0
 
 Reference documentation for bash helper functions used in debate orchestration.
+
+> **Cross-platform note:** If `flock` or `jq` are unavailable (Windows, some macOS), use `tools/atomic-json.mjs` instead. See the Node.js Alternative section at the bottom.
 
 ---
 
@@ -72,9 +74,70 @@ update_debate_state "$STATE_FILE" "$new_state"
 
 ---
 
+## Atomic Index Updates
+
+Use this helper to safely append to index.json. Protects against corruption when running parallel debates.
+
+```bash
+update_debate_index() {
+    local index_file="$1"
+    local debate_id="$2"
+
+    _atomic_index_write() {
+        # Initialize if missing
+        if [[ ! -f "$index_file" ]]; then
+            echo '{"debates":[]}' > "$index_file"
+        fi
+
+        local current
+        current=$(cat "$index_file")
+
+        # Check if already present
+        if echo "$current" | jq -e --arg id "$debate_id" '.debates | index($id)' &>/dev/null; then
+            return 0  # Already in index
+        fi
+
+        # Append and write atomically
+        local updated
+        updated=$(echo "$current" | jq --arg id "$debate_id" '.debates += [$id]')
+
+        echo "$updated" > "${index_file}.tmp" || return 1
+
+        if command -v jq &>/dev/null && ! jq empty "${index_file}.tmp" 2>/dev/null; then
+            rm "${index_file}.tmp" 2>/dev/null
+            echo "ERROR: Invalid JSON when updating index" >&2
+            return 1
+        fi
+
+        mv "${index_file}.tmp" "$index_file" || return 1
+    }
+
+    # Use flock if available
+    if command -v flock &>/dev/null; then
+        (
+            flock -x -w 5 200 || {
+                echo "ERROR: Could not acquire lock on $index_file after 5s" >&2
+                return 1
+            }
+            _atomic_index_write
+        ) 200>"${index_file}.lock"
+    else
+        echo "WARN: flock not available, writing index without lock" >&2
+        _atomic_index_write
+    fi
+}
+```
+
+**Usage:**
+```bash
+update_debate_index "$DEBATES_DIR/index.json" "003-redis-vs-memcached"
+```
+
+---
+
 ## Exponential Backoff Retry
 
-Retry advisor calls with intelligent failure detection.
+Retry advisor calls with intelligent failure detection and telemetry.
 
 ```bash
 run_advisor_with_retry() {
@@ -82,9 +145,11 @@ run_advisor_with_retry() {
     local prompt="$2"
     local max_retries="${3:-3}"
     local base_timeout="${4:-90}"
+    local state_file="${5:-}"  # Optional: pass state.json path for telemetry
 
     local attempt=1
     local timeout=$base_timeout
+    local total_retries=0
 
     while [[ $attempt -le $max_retries ]]; do
         echo "[$advisor] Attempt $attempt/$max_retries (timeout: ${timeout}s)" >&2
@@ -94,6 +159,27 @@ run_advisor_with_retry() {
         fi
 
         local error_output=$(get_last_error 2>&1)
+        total_retries=$((total_retries + 1))
+
+        # Record error in state.json if path provided
+        if [[ -n "$state_file" && -f "$state_file" ]]; then
+            local error_msg="${error_output:0:200}"  # Cap at 200 chars
+            local failure_mode=$(detect_failure_mode "$advisor" "$error_output")
+            local current_round=$(jq -r '.current_round // 0' "$state_file" 2>/dev/null)
+            local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            local updated
+            updated=$(jq \
+                --arg type "$failure_mode" \
+                --arg msg "$error_msg" \
+                --arg adv "$advisor" \
+                --arg ts "$timestamp" \
+                --argjson round "$current_round" \
+                --argjson retries "$total_retries" \
+                '.last_error = {type: $type, message: $msg, round: $round, advisor: $adv, timestamp: $ts} |
+                 .telemetry.retries_count = ((.telemetry.retries_count // 0) + $retries)' \
+                "$state_file")
+            update_debate_state "$state_file" "$updated"
+        fi
 
         if [[ $attempt -eq $max_retries ]]; then
             echo "ERROR: [$advisor] Failed after $max_retries attempts" >&2
@@ -178,6 +264,39 @@ detect_failure_mode() {
 
 ---
 
+## Round Duration Tracking
+
+Record how long each round takes for telemetry.
+
+```bash
+record_round_duration() {
+    local state_file="$1"
+    local round_number="$2"
+    local duration_seconds="$3"
+
+    if [[ -f "$state_file" ]]; then
+        local updated
+        updated=$(jq \
+            --arg round "$round_number" \
+            --argjson dur "$duration_seconds" \
+            '.telemetry.round_durations[$round] = $dur' \
+            "$state_file")
+        update_debate_state "$state_file" "$updated"
+    fi
+}
+```
+
+**Usage:**
+```bash
+start_time=$(date +%s)
+# ... run round ...
+end_time=$(date +%s)
+duration=$((end_time - start_time))
+record_round_duration "$STATE_FILE" "1" "$duration"
+```
+
+---
+
 ## Contextual Error Messages
 
 User-friendly error output with troubleshooting steps.
@@ -245,3 +364,22 @@ log_contextual_error "gemini" "Session Resume Failed" \
 
 log_advisor_success "gemini" 1 287 12
 ```
+
+---
+
+## Node.js Alternative
+
+For environments without `flock` or `jq` (Windows, some macOS), use the cross-platform Node.js helper:
+
+```bash
+# Atomic state write
+node tools/atomic-json.mjs write state.json '{"version":2,"status":"in_progress",...}'
+
+# Atomic index append
+node tools/atomic-json.mjs append-index index.json '{"debate_id":"003-redis-vs-memcached"}'
+
+# Read with lock
+node tools/atomic-json.mjs read state.json
+```
+
+See `tools/atomic-json.mjs` for implementation details. Zero external dependencies.

--- a/skills/debate/tools/atomic-json.mjs
+++ b/skills/debate/tools/atomic-json.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+
+/**
+ * atomic-json.mjs — Cross-platform atomic JSON file operations
+ *
+ * Zero external dependencies. Works on Linux, macOS, and Windows.
+ * Replaces bash helpers (flock + jq) for environments that lack them.
+ *
+ * Usage:
+ *   node atomic-json.mjs write <file> <json-string>
+ *   node atomic-json.mjs read <file>
+ *   node atomic-json.mjs append-index <index-file> <debate-id>
+ *   node atomic-json.mjs merge <file> <partial-json>
+ */
+
+import { readFileSync, writeFileSync, renameSync, unlinkSync, existsSync, mkdirSync, openSync, closeSync, ftruncateSync, writeSync, readSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+// --- Lock Implementation (mkdir-based, cross-platform) ---
+
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_RETRY_MS = 50;
+
+function acquireLock(filePath) {
+  const lockDir = filePath + '.lock';
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      mkdirSync(lockDir);
+      return lockDir;
+    } catch (err) {
+      if (err.code === 'EEXIST') {
+        // Check for stale lock (older than 30s)
+        try {
+          const stat = statSync(lockDir);
+          if (Date.now() - stat.mtimeMs > 30000) {
+            try { unlinkSync(lockDir); } catch { /* ignore */ }
+            try { require('fs').rmdirSync(lockDir); } catch { /* ignore */ }
+            continue;
+          }
+        } catch { /* stat failed, lock may have been released */ }
+
+        // Wait and retry
+        const waitUntil = Date.now() + LOCK_RETRY_MS;
+        while (Date.now() < waitUntil) { /* busy wait */ }
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw new Error(`Could not acquire lock on ${filePath} after ${LOCK_TIMEOUT_MS}ms`);
+}
+
+function releaseLock(lockDir) {
+  try {
+    // rmdir only works on empty directories — that's our lock
+    require('fs').rmdirSync(lockDir);
+  } catch {
+    // Already released or doesn't exist
+  }
+}
+
+// Use dynamic import for fs.rmdirSync since we're in ESM
+import { rmdirSync } from 'node:fs';
+
+function releaseLockESM(lockDir) {
+  try {
+    rmdirSync(lockDir);
+  } catch {
+    // Already released
+  }
+}
+
+// --- Atomic Write ---
+
+function atomicWrite(filePath, data) {
+  const absPath = resolve(filePath);
+  const tmpPath = absPath + '.tmp.' + process.pid;
+
+  // Validate JSON
+  try {
+    JSON.parse(data);
+  } catch (err) {
+    console.error(`ERROR: Invalid JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  const lockDir = acquireLock(absPath);
+  try {
+    // Ensure parent directory exists
+    const dir = dirname(absPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    // Write to temp file
+    writeFileSync(tmpPath, data + '\n', 'utf8');
+
+    // Atomic rename
+    renameSync(tmpPath, absPath);
+  } catch (err) {
+    // Cleanup temp file on failure
+    try { unlinkSync(tmpPath); } catch { /* ignore */ }
+    throw err;
+  } finally {
+    releaseLockESM(lockDir);
+  }
+}
+
+// --- Atomic Read ---
+
+function atomicRead(filePath) {
+  const absPath = resolve(filePath);
+
+  if (!existsSync(absPath)) {
+    console.error(`ERROR: File not found: ${absPath}`);
+    process.exit(1);
+  }
+
+  const lockDir = acquireLock(absPath);
+  try {
+    const content = readFileSync(absPath, 'utf8');
+    // Validate it's valid JSON
+    JSON.parse(content);
+    return content.trim();
+  } finally {
+    releaseLockESM(lockDir);
+  }
+}
+
+// --- Append to Index ---
+
+function appendIndex(indexFile, debateId) {
+  const absPath = resolve(indexFile);
+  const lockDir = acquireLock(absPath);
+
+  try {
+    let index;
+
+    if (existsSync(absPath)) {
+      const content = readFileSync(absPath, 'utf8');
+      index = JSON.parse(content);
+    } else {
+      // Ensure parent directory exists
+      const dir = dirname(absPath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+      index = { debates: [] };
+    }
+
+    // Check if already present
+    if (index.debates.includes(debateId)) {
+      console.log(`Already in index: ${debateId}`);
+      return;
+    }
+
+    // Append
+    index.debates.push(debateId);
+
+    // Atomic write
+    const tmpPath = absPath + '.tmp.' + process.pid;
+    writeFileSync(tmpPath, JSON.stringify(index, null, 2) + '\n', 'utf8');
+    renameSync(tmpPath, absPath);
+
+    console.log(`Added to index: ${debateId}`);
+  } catch (err) {
+    console.error(`ERROR: Failed to update index: ${err.message}`);
+    process.exit(1);
+  } finally {
+    releaseLockESM(lockDir);
+  }
+}
+
+// --- Merge (partial update) ---
+
+function mergeJson(filePath, partialJson) {
+  const absPath = resolve(filePath);
+
+  let partial;
+  try {
+    partial = JSON.parse(partialJson);
+  } catch (err) {
+    console.error(`ERROR: Invalid partial JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  const lockDir = acquireLock(absPath);
+  try {
+    let current = {};
+    if (existsSync(absPath)) {
+      current = JSON.parse(readFileSync(absPath, 'utf8'));
+    }
+
+    // Shallow merge (top-level keys)
+    const merged = { ...current, ...partial };
+
+    // Deep merge for known nested objects
+    if (current.telemetry && partial.telemetry) {
+      merged.telemetry = { ...current.telemetry, ...partial.telemetry };
+      if (current.telemetry.round_durations && partial.telemetry.round_durations) {
+        merged.telemetry.round_durations = {
+          ...current.telemetry.round_durations,
+          ...partial.telemetry.round_durations
+        };
+      }
+    }
+    if (current.sessions && partial.sessions) {
+      merged.sessions = { ...current.sessions, ...partial.sessions };
+    }
+
+    const tmpPath = absPath + '.tmp.' + process.pid;
+    writeFileSync(tmpPath, JSON.stringify(merged, null, 2) + '\n', 'utf8');
+    renameSync(tmpPath, absPath);
+  } catch (err) {
+    console.error(`ERROR: Failed to merge: ${err.message}`);
+    process.exit(1);
+  } finally {
+    releaseLockESM(lockDir);
+  }
+}
+
+// --- CLI Entry Point ---
+
+const [,, command, ...args] = process.argv;
+
+switch (command) {
+  case 'write': {
+    if (args.length < 2) {
+      console.error('Usage: atomic-json.mjs write <file> <json-string>');
+      process.exit(1);
+    }
+    atomicWrite(args[0], args[1]);
+    break;
+  }
+
+  case 'read': {
+    if (args.length < 1) {
+      console.error('Usage: atomic-json.mjs read <file>');
+      process.exit(1);
+    }
+    console.log(atomicRead(args[0]));
+    break;
+  }
+
+  case 'append-index': {
+    if (args.length < 2) {
+      console.error('Usage: atomic-json.mjs append-index <index-file> <debate-id>');
+      process.exit(1);
+    }
+    appendIndex(args[0], args[1]);
+    break;
+  }
+
+  case 'merge': {
+    if (args.length < 2) {
+      console.error('Usage: atomic-json.mjs merge <file> <partial-json>');
+      process.exit(1);
+    }
+    mergeJson(args[0], args[1]);
+    break;
+  }
+
+  default:
+    console.error(`Unknown command: ${command}`);
+    console.error('Commands: write, read, append-index, merge');
+    process.exit(1);
+}

--- a/skills/debate/viewer.html
+++ b/skills/debate/viewer.html
@@ -23,6 +23,23 @@
             --claude-color: #d97706;
         }
 
+        [data-theme="light"] {
+            --bg-primary: #ffffff;
+            --bg-secondary: #f6f8fa;
+            --bg-tertiary: #eaeef2;
+            --border: #d0d7de;
+            --text-primary: #1f2328;
+            --text-secondary: #656d76;
+            --accent-blue: #0969da;
+            --accent-green: #1a7f37;
+            --accent-purple: #8250df;
+            --accent-orange: #bf8700;
+            --accent-red: #cf222e;
+            --gemini-color: #1a73e8;
+            --codex-color: #0d8c6d;
+            --claude-color: #b45309;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -51,18 +68,29 @@
         .sidebar-header {
             padding: 20px;
             border-bottom: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
 
         .sidebar-header h1 {
             font-size: 18px;
             font-weight: 600;
-            display: flex;
-            align-items: center;
-            gap: 8px;
         }
 
-        .sidebar-header h1::before {
-            content: "🤖";
+        .theme-toggle {
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            color: var(--text-primary);
+            padding: 6px 10px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            transition: all 0.2s;
+        }
+
+        .theme-toggle:hover {
+            background: var(--border);
         }
 
         .debate-list {
@@ -99,7 +127,8 @@
             font-size: 12px;
             color: var(--text-secondary);
             display: flex;
-            gap: 12px;
+            gap: 8px;
+            flex-wrap: wrap;
         }
 
         .status-badge {
@@ -117,6 +146,11 @@
         .status-in_progress {
             background: rgba(210, 153, 34, 0.2);
             color: var(--accent-orange);
+        }
+
+        .status-early_stop {
+            background: rgba(168, 113, 247, 0.2);
+            color: var(--accent-purple);
         }
 
         /* Main Content */
@@ -144,6 +178,13 @@
             gap: 16px;
             font-size: 13px;
             color: var(--text-secondary);
+            flex-wrap: wrap;
+        }
+
+        .meta-tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
         }
 
         /* Tabs */
@@ -293,6 +334,13 @@
             gap: 8px;
         }
 
+        .round-duration {
+            font-weight: 400;
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-left: auto;
+        }
+
         .round-responses {
             display: grid;
             grid-template-columns: 1fr 1fr;
@@ -335,6 +383,96 @@
         .advisor-claude {
             background: rgba(217, 119, 6, 0.2);
             color: var(--claude-color);
+        }
+
+        /* Copy Button */
+        .copy-btn {
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            color: var(--text-secondary);
+            padding: 8px 14px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 500;
+            transition: all 0.2s;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .copy-btn:hover {
+            background: var(--border);
+            color: var(--text-primary);
+        }
+
+        .copy-btn.copied {
+            background: rgba(63, 185, 80, 0.2);
+            border-color: var(--accent-green);
+            color: var(--accent-green);
+        }
+
+        .content-toolbar {
+            display: flex;
+            justify-content: flex-end;
+            margin-bottom: 16px;
+            gap: 8px;
+        }
+
+        /* Telemetry Panel */
+        .telemetry-panel {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-top: 16px;
+        }
+
+        .telemetry-panel h4 {
+            font-size: 14px;
+            margin-bottom: 12px;
+            color: var(--accent-blue);
+        }
+
+        .telemetry-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 12px;
+        }
+
+        .telemetry-stat {
+            background: var(--bg-tertiary);
+            padding: 10px 14px;
+            border-radius: 6px;
+        }
+
+        .telemetry-stat-label {
+            font-size: 11px;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .telemetry-stat-value {
+            font-size: 18px;
+            font-weight: 600;
+            margin-top: 4px;
+        }
+
+        /* Error Banner */
+        .error-banner {
+            background: rgba(248, 81, 73, 0.1);
+            border: 1px solid rgba(248, 81, 73, 0.3);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-top: 12px;
+            font-size: 13px;
+        }
+
+        .error-banner-title {
+            font-weight: 600;
+            color: var(--accent-red);
+            margin-bottom: 4px;
         }
 
         /* Empty State */
@@ -393,8 +531,8 @@
         }
 
         .refresh-btn:hover {
-            background: #4a90e2;
             transform: translateY(-2px);
+            box-shadow: 0 6px 16px rgba(0,0,0,0.4);
         }
 
         /* Instructions */
@@ -416,16 +554,29 @@
             padding: 2px 6px;
             border-radius: 4px;
         }
+
+        /* Version Footer */
+        .sidebar-footer {
+            padding: 12px 20px;
+            border-top: 1px solid var(--border);
+            font-size: 11px;
+            color: var(--text-secondary);
+            text-align: center;
+        }
     </style>
 </head>
 <body>
     <div class="sidebar">
         <div class="sidebar-header">
             <h1>AI Debate Hub</h1>
+            <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">
+                <span id="themeIcon">Light</span>
+            </button>
         </div>
         <div class="debate-list" id="debateList">
             <div class="loading">Loading debates...</div>
         </div>
+        <div class="sidebar-footer">v6.0.0</div>
     </div>
 
     <div class="main-content">
@@ -446,14 +597,14 @@
 
         <div class="content-area" id="contentArea">
             <div class="empty-state">
-                <div class="empty-state-icon">💬</div>
-                <p>Select a debate to view its content</p>
+                <div class="empty-state-icon">Select a debate</div>
+                <p>Choose a debate from the sidebar to view its content</p>
             </div>
         </div>
     </div>
 
     <button class="refresh-btn" onclick="loadDebates()">
-        🔄 Refresh
+        Refresh
     </button>
 
     <script>
@@ -461,11 +612,28 @@
         let debates = [];
         let currentDebate = null;
         let currentTab = 'synthesis';
+        let rawFiles = {};  // Cache for copy-to-clipboard
+
+        // Theme management
+        function toggleTheme() {
+            const html = document.documentElement;
+            const current = html.getAttribute('data-theme');
+            const next = current === 'light' ? 'dark' : 'light';
+            html.setAttribute('data-theme', next);
+            document.getElementById('themeIcon').textContent = next === 'light' ? 'Dark' : 'Light';
+            localStorage.setItem('debate-viewer-theme', next);
+        }
+
+        // Restore saved theme
+        (function() {
+            const saved = localStorage.getItem('debate-viewer-theme');
+            if (saved === 'light') {
+                document.documentElement.setAttribute('data-theme', 'light');
+                document.getElementById('themeIcon').textContent = 'Dark';
+            }
+        })();
 
         // Auto-discover debates from index.json
-        // The /debate skill maintains this index file automatically
-        // Viewer runs from debates/ folder, so index.json is in same directory
-
         async function loadDebates() {
             const debateList = document.getElementById('debateList');
             debateList.innerHTML = '<div class="loading">Loading debates...</div>';
@@ -478,7 +646,6 @@
                 const response = await fetch('index.json');
                 if (response.ok) {
                     const index = await response.json();
-                    // Debates are subdirectories in same folder as viewer
                     debatePaths.push(...index.debates);
                 }
             } catch (e) {
@@ -491,13 +658,16 @@
                     const stateResponse = await fetch(`${path}/state.json`);
                     if (stateResponse.ok) {
                         const state = await stateResponse.json();
+                        const earlyStop = state.early_stop === true;
                         debates.push({
                             path: path,
                             state: state,
                             topic: state.topic || path.split('/').pop(),
-                            status: state.status || 'unknown',
+                            status: earlyStop ? 'early_stop' : (state.status || 'unknown'),
+                            displayStatus: earlyStop ? 'early stop' : (state.status || 'unknown'),
                             rounds: state.current_round || state.rounds_total || state.rounds_completed?.length || 0,
-                            date: state.created_at || 'Unknown'
+                            date: state.created_at || 'Unknown',
+                            moderatorStyle: state.moderator_style || 'guided'
                         });
                     }
                 } catch (e) {
@@ -519,7 +689,7 @@
                         <p><code>python -m http.server 8080</code></p>
                         <p>Then open <code>http://localhost:8080/viewer.html</code></p>
                         <p style="margin-top: 12px; font-size: 11px; color: var(--text-secondary)">
-                            Debates are discovered via <code>.debates/index.json</code>
+                            Debates are discovered via <code>index.json</code>
                         </p>
                     </div>
                 `;
@@ -529,13 +699,20 @@
             debateList.innerHTML = debates.map((debate, idx) => `
                 <div class="debate-item ${currentDebate === idx ? 'active' : ''}"
                      onclick="selectDebate(${idx})">
-                    <div class="debate-item-title">${debate.topic}</div>
+                    <div class="debate-item-title">${escapeHtml(debate.topic)}</div>
                     <div class="debate-item-meta">
-                        <span class="status-badge status-${debate.status}">${debate.status}</span>
+                        <span class="status-badge status-${debate.status}">${debate.displayStatus}</span>
                         <span>${debate.rounds} rounds</span>
+                        <span>${debate.moderatorStyle}</span>
                     </div>
                 </div>
             `).join('');
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
         }
 
         async function selectDebate(idx) {
@@ -548,11 +725,14 @@
             // Update header
             const header = document.getElementById('contentHeader');
             header.innerHTML = `
-                <h2>${debate.topic}</h2>
+                <h2>${escapeHtml(debate.topic)}</h2>
                 <div class="content-header-meta">
-                    <span>${debate.status}</span>
-                    <span>${debate.rounds} rounds</span>
-                    <span>${debate.date}</span>
+                    <span class="meta-tag">
+                        <span class="status-badge status-${debate.status}">${debate.displayStatus}</span>
+                    </span>
+                    <span class="meta-tag">${debate.rounds} rounds</span>
+                    <span class="meta-tag">Moderator: ${debate.moderatorStyle}</span>
+                    <span class="meta-tag">${debate.date}</span>
                 </div>
             `;
 
@@ -576,10 +756,16 @@
                     case 'transcript':
                         try {
                             const transcript = await fetchFile(`${debate.path}/transcript.md`);
-                            contentArea.innerHTML = `<div class="markdown-content">${marked.parse(transcript)}</div>`;
+                            rawFiles.transcript = transcript;
+                            contentArea.innerHTML = `
+                                <div class="content-toolbar">
+                                    <button class="copy-btn" onclick="copyToClipboard('transcript', this)">Copy transcript</button>
+                                </div>
+                                <div class="markdown-content">${marked.parse(transcript)}</div>
+                            `;
                         } catch (e) {
                             contentArea.innerHTML = `<div class="empty-state">
-                                <div class="empty-state-icon">📝</div>
+                                <div class="empty-state-icon">Transcript</div>
                                 <p>No transcript file. View individual rounds in the <strong>Rounds</strong> tab.</p>
                             </div>`;
                         }
@@ -588,10 +774,16 @@
                     case 'synthesis':
                         try {
                             const synthesis = await fetchFile(`${debate.path}/synthesis.md`);
-                            contentArea.innerHTML = `<div class="markdown-content">${marked.parse(synthesis)}</div>`;
+                            rawFiles.synthesis = synthesis;
+                            contentArea.innerHTML = `
+                                <div class="content-toolbar">
+                                    <button class="copy-btn" onclick="copyToClipboard('synthesis', this)">Copy synthesis</button>
+                                </div>
+                                <div class="markdown-content">${marked.parse(synthesis)}</div>
+                            `;
                         } catch (e) {
                             contentArea.innerHTML = `<div class="empty-state">
-                                <div class="empty-state-icon">🔄</div>
+                                <div class="empty-state-icon">Synthesis</div>
                                 <p>No synthesis yet. Debate may still be in progress.</p>
                             </div>`;
                         }
@@ -600,18 +792,89 @@
                     case 'context':
                         try {
                             const context = await fetchFile(`${debate.path}/context.md`);
-                            contentArea.innerHTML = `<div class="markdown-content">${marked.parse(context)}</div>`;
+                            rawFiles.context = context;
+                            contentArea.innerHTML = `
+                                <div class="content-toolbar">
+                                    <button class="copy-btn" onclick="copyToClipboard('context', this)">Copy context</button>
+                                </div>
+                                <div class="markdown-content">${marked.parse(context)}</div>
+                            `;
                         } catch (e) {
                             contentArea.innerHTML = `<div class="empty-state">
-                                <div class="empty-state-icon">📋</div>
+                                <div class="empty-state-icon">Context</div>
                                 <p>No context file for this debate.</p>
                             </div>`;
                         }
                         break;
 
                     case 'state':
-                        const state = await fetchFile(`${debate.path}/state.json`);
-                        contentArea.innerHTML = `<pre class="json-view">${JSON.stringify(JSON.parse(state), null, 2)}</pre>`;
+                        const stateText = await fetchFile(`${debate.path}/state.json`);
+                        const stateObj = JSON.parse(stateText);
+                        rawFiles.state = stateText;
+
+                        let stateHtml = `
+                            <div class="content-toolbar">
+                                <button class="copy-btn" onclick="copyToClipboard('state', this)">Copy JSON</button>
+                            </div>
+                            <pre class="json-view">${escapeHtml(JSON.stringify(stateObj, null, 2))}</pre>
+                        `;
+
+                        // Telemetry panel
+                        if (stateObj.telemetry) {
+                            const tel = stateObj.telemetry;
+                            let telStats = '';
+
+                            if (tel.round_durations) {
+                                const durations = Object.values(tel.round_durations);
+                                const total = durations.reduce((a, b) => a + b, 0);
+                                telStats += `
+                                    <div class="telemetry-stat">
+                                        <div class="telemetry-stat-label">Total Duration</div>
+                                        <div class="telemetry-stat-value">${total}s</div>
+                                    </div>
+                                `;
+                                for (const [round, dur] of Object.entries(tel.round_durations)) {
+                                    telStats += `
+                                        <div class="telemetry-stat">
+                                            <div class="telemetry-stat-label">Round ${round}</div>
+                                            <div class="telemetry-stat-value">${dur}s</div>
+                                        </div>
+                                    `;
+                                }
+                            }
+
+                            if (tel.retries_count != null) {
+                                telStats += `
+                                    <div class="telemetry-stat">
+                                        <div class="telemetry-stat-label">Total Retries</div>
+                                        <div class="telemetry-stat-value">${tel.retries_count}</div>
+                                    </div>
+                                `;
+                            }
+
+                            if (telStats) {
+                                stateHtml += `
+                                    <div class="telemetry-panel">
+                                        <h4>Telemetry</h4>
+                                        <div class="telemetry-grid">${telStats}</div>
+                                    </div>
+                                `;
+                            }
+                        }
+
+                        // Last error banner
+                        if (stateObj.last_error) {
+                            const err = stateObj.last_error;
+                            stateHtml += `
+                                <div class="error-banner">
+                                    <div class="error-banner-title">Last Error: ${escapeHtml(err.type || 'unknown')}</div>
+                                    <div>Advisor: ${escapeHtml(err.advisor || '?')} | Round: ${err.round || '?'} | ${escapeHtml(err.timestamp || '')}</div>
+                                    <div style="margin-top: 4px; font-size: 12px; color: var(--text-secondary)">${escapeHtml(err.message || '')}</div>
+                                </div>
+                            `;
+                        }
+
+                        contentArea.innerHTML = stateHtml;
                         break;
 
                     case 'rounds':
@@ -620,8 +883,8 @@
                 }
             } catch (e) {
                 contentArea.innerHTML = `<div class="empty-state">
-                    <div class="empty-state-icon">❌</div>
-                    <p>Failed to load content: ${e.message}</p>
+                    <div class="empty-state-icon">Error</div>
+                    <p>Failed to load content: ${escapeHtml(e.message)}</p>
                 </div>`;
             }
         }
@@ -634,7 +897,7 @@
             const numRounds = state.current_round || state.rounds_total ||
                               (state.rounds_completed ? state.rounds_completed.length : 0);
 
-            // Determine participants - default to gemini/codex, but support claude too
+            // Determine participants
             const participants = state.participants || ['gemini', 'codex'];
             const isThreeWay = participants.includes('claude');
 
@@ -654,18 +917,22 @@
                     }
                 }
 
-                // Determine grid columns based on participant count
+                // Grid columns based on participant count
                 const gridCols = isThreeWay ? 'grid-template-columns: 1fr 1fr 1fr;' : 'grid-template-columns: 1fr 1fr;';
+
+                // Round duration from telemetry
+                const duration = state.telemetry?.round_durations?.[String(roundNum)];
+                const durationHtml = duration ? `<span class="round-duration">${duration}s</span>` : '';
 
                 html += `
                     <div class="round-card">
                         <div class="round-header">
                             <span>Round ${roundNum}</span>
+                            ${durationHtml}
                         </div>
                         <div class="round-responses" style="${gridCols}">
                 `;
 
-                // Add response for each participant
                 for (const participant of participants) {
                     const badgeClass = `advisor-${participant}`;
                     const displayName = participant.charAt(0).toUpperCase() + participant.slice(1);
@@ -685,6 +952,17 @@
                 `;
             }
 
+            // Early stop notice
+            if (state.early_stop) {
+                html += `
+                    <div class="round-card" style="border-color: var(--accent-purple);">
+                        <div class="round-header" style="background: rgba(168, 113, 247, 0.1); color: var(--accent-purple);">
+                            Early Stop: ${escapeHtml(state.early_stop_reason || 'consensus reached')}
+                        </div>
+                    </div>
+                `;
+            }
+
             html += '</div>';
             contentArea.innerHTML = html;
         }
@@ -693,6 +971,38 @@
             const response = await fetch(path);
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             return await response.text();
+        }
+
+        async function copyToClipboard(key, btn) {
+            const text = rawFiles[key];
+            if (!text) return;
+
+            try {
+                await navigator.clipboard.writeText(text);
+                btn.classList.add('copied');
+                btn.textContent = 'Copied!';
+                setTimeout(() => {
+                    btn.classList.remove('copied');
+                    btn.textContent = `Copy ${key}`;
+                }, 2000);
+            } catch (e) {
+                // Fallback for non-HTTPS
+                const textarea = document.createElement('textarea');
+                textarea.value = text;
+                textarea.style.position = 'fixed';
+                textarea.style.opacity = '0';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+
+                btn.classList.add('copied');
+                btn.textContent = 'Copied!';
+                setTimeout(() => {
+                    btn.classList.remove('copied');
+                    btn.textContent = `Copy ${key}`;
+                }, 2000);
+            }
         }
 
         // Tab click handler


### PR DESCRIPTION
PR #1 — Cleanup & consistency:
- Unified version to v6.0.0 across SKILL.md and README.md
- Added disable-model-invocation: true to frontmatter
- Implemented --moderator-style flag (transparent/guided/authoritative)
- Added requirements table and Windows section to README
- SKILL.md is now single source of truth for flags

PR #2 — Technical robustness:
- Added update_debate_index() atomic helper for parallel-safe index.json
- Created tools/atomic-json.mjs (zero-dep, cross-platform Node.js alternative)
- Added telemetry fields to state.json (round_durations, retries_count, last_error)
- Retry helper now records errors in state.json with capped messages

PR #3 — Viewer enhancements:
- Added copy-to-clipboard for synthesis/transcript/context/state
- Added light/dark theme toggle with localStorage persistence
- Added telemetry panel with round durations and retry counts
- Added last_error banner display
- Added early-stop badge and moderator style in metadata
- XSS-safe rendering with escapeHtml throughout

PR #4 — Debate quality:
- Added structured output contract per advisor (position, confidence,
  assumptions, risks, what-would-change-my-mind)
- Added early-stop logic (skip remaining rounds on consensus in round 2+)
- Synthesis now includes advisor comparison table and risk matrix
- Added prompt hardening note: "do not invent facts"

https://claude.ai/code/session_01AbT3Reng3z3ZS1TB5CfkT3